### PR TITLE
Adds filename to sha256 file for use with `sha256 -c`

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -108,7 +108,7 @@ if ($bucket->head_key("$releasePrefix")) {
 
         if (! -e $dstFile) {
             print STDERR "downloading $srcFile to $dstFile...\n";
-            write_file("$dstFile.sha256", $sha256_expected);
+            write_file("$dstFile.sha256", "$sha256_expected  $dstName");
             system("NIX_REMOTE=https://cache.nixos.org/ nix cat-store '$srcFile' > '$dstFile.tmp'") == 0
                 or die "unable to fetch $srcFile\n";
             rename("$dstFile.tmp", $dstFile) or die;


### PR DESCRIPTION
The manpage says:

> The  sums  are  computed as described in FIPS-180-2.  When checking, the input should be a former
> output of this program.  The default mode is to print a line with checksum, **a space, a  character
> indicating  input  mode ('*' for binary, ' ' for text or where binary is insignificant),** and name
> for each FILE.

By adding the filename to the generated sha256 file, a user would be
able to download an iso, the sha256 file, then use `sha256 -c
[file].iso.sha256` to verify the file.

* * *

This fixes [nixos-homepage#224](https://github.com/NixOS/nixos-homepage/issues/224)

* * *

### Additional notes

#### Breaking assumptions

This could break assumptions where the `.sha256` files were previously used as they were. I have briefly looked and couldn't find evidence of such use.

#### Testing

I couldn't test the entire changes in-place, but here's how I tested them:

Using [this test.pl file](https://gist.github.com/samueldr/fad9d00b84f3337604b741e058650c4a), 

```
~/.../nixos/nixos-channel-scripts $ nix-shell -p perl -p perlPackages.FileSlurp
[nix-shell:~/.../nixos/nixos-channel-scripts]$ ./test.pl
[nix-shell:~/.../nixos/nixos-channel-scripts]$ cd tmp/
[nix-shell:~/.../nixos-channel-scripts/tmp]$ ls
testing  testing.sha256
[nix-shell:~/.../nixos-channel-scripts/tmp]$ sha256sum -c testing.sha256
testing: OK
```

So at least, the basic code is expected to work.

Am I right in assuming there is no test suite for the mirroring script?