### PR TITLE
file-cache: use the right exception type for parse error

### DIFF
--- a/file-cache.hh
+++ b/file-cache.hh
@@ -140,7 +140,7 @@ public:
                     throw Error("NAR index for ‘%s’ has an unsupported version", storePath);
 
                 recurse("", ls.at("root"));
-            } catch (std::invalid_argument & e) {
+            } catch (json::parse_error & e) {
                 // FIXME: some filenames have non-UTF8 characters in them,
                 // which is not supported by nlohmann::json. So we have to
                 // skip the entire package.


### PR DESCRIPTION
```
error: [json.exception.parse_error.101] parse error at 195: syntax error - invalid string: ill-formed UTF-8 byte; last read: '"bokml'; expected string literal
```

This is most probably caused by the upgrade in [nixos-org-configurations/1b74e019b166d37a1510a99aeea86a0fa656854a](https://github.com/NixOS/nixos-org-configurations/commit/1b74e019b166d37a1510a99aeea86a0fa656854a)
that, in turn, caused nlohmann_json to go from 2.1.0 -> 3.2.0

I haven't found concrete evidence in the changelog as to a change
changing the exception type. Though, the timing for failures matches
with this update.

Furthermore, once this fix is applied, launching the update locally
works fine.

* * *

This was tested [by neutering the S3 stuff](https://gist.github.com/a4578caf7cda38a9ba8c331acfe3c45c) and running

```
$ nix-build && nix-shell -p ./result
$ mirror-nixos-branch nixos-18.09 https://hydra.nixos.org/job/nixos/release-18.09/tested/latest-finished
```

Do note that this doesn't seem affect the -small channels, while affecting the "big" channels.