### PR TITLE
mirror: sets hash format to base16

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -115,7 +115,7 @@ if ($bucket->head_key("$releasePrefix")) {
         }
 
         if (-e "$dstFile.sha256") {
-            my $sha256_actual = `nix hash-file --type sha256 '$dstFile'`;
+            my $sha256_actual = `nix hash-file --base16 --type sha256 '$dstFile'`;
             chomp $sha256_actual;
             if ($sha256_expected ne $sha256_actual) {
                 print STDERR "file $dstFile is corrupt $sha256_expected $sha256_actual\n";


### PR DESCRIPTION
From the nix 2.2 changelog:

> nix hash-file and nix hash-path now print hashes in SRI
> format by default. They also use SHA-256 by default
> instead of SHA-512 because that's what we use most of the
> time in Nixpkgs.