### PR TITLE
Namespace channel pushes in nixpkgs

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -226,7 +226,7 @@ rename("$channelsDir/.htaccess.tmp", "$channelsDir/.htaccess") or die;
 # Update the nixos-* branch in the nixpkgs repo. Also update the
 # nixpkgs-channels repo for compatibility.
 system("git remote update origin >&2") == 0 or die;
-system("git push origin $rev:refs/heads/$channelName >&2") == 0 or die;
+system("git push origin $rev:refs/heads/channels/$channelName >&2") == 0 or die;
 system("git push channels $rev:refs/heads/$channelName >&2") == 0 or die;
 
 flock($lockfile, LOCK_UN) or die "cannot release channels lock\n";


### PR DESCRIPTION
PRs to NixOS are a bit confused about if they should PR to release-* or nixos-* or nixpkgs-*. I think namespacing the refs will go a long way in making it more obvious.