### PR TITLE
mirror-nixos-branch.pl: exit 0 if the channel would go back in time

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -77,7 +77,11 @@ my @curReleaseUrl = split(/\//, read_file("$channelsDir/$channelName", err_mode 
 my $curRelease = pop @curReleaseUrl;
 my $d = `NIX_PATH= nix-instantiate --eval -E "builtins.compareVersions (builtins.parseDrvName \\"$curRelease\\").version (builtins.parseDrvName \\"$releaseName\\").version"`;
 chomp $d;
-die "channel would go back in time from $curRelease to $releaseName, bailing out\n" if $d == 1;
+if ($d == 1) {
+    warn("channel would go back in time from $curRelease to $releaseName, bailing out\n");
+    exit;
+}
+
 exit if $d == 0;
 
 if ($bucket->head_key("$releasePrefix")) {


### PR DESCRIPTION
Prometheus now has a configured alert if an update job fails for a
while. Going back in time is not so unusual:

1. a hydra evaluation completes with some failed jobs
2. the channel advances to this commit
3. an admin restarts a failed job
4. the channel would go backward because the evaluation is complete

Since it is not a problem, make it a non-problematic exit code.