### PR TITLE
mirror-branch: Bails when failing to run nix-instantiate

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -76,6 +76,14 @@ print STDERR "release is ‘$releaseName’ (build $releaseId), eval is $evalId,
 my @curReleaseUrl = split(/\//, read_file("$channelsDir/$channelName", err_mode => 'quiet') // "");
 my $curRelease = pop @curReleaseUrl;
 my $d = `NIX_PATH= nix-instantiate --eval -E "builtins.compareVersions (builtins.parseDrvName \\"$curRelease\\").version (builtins.parseDrvName \\"$releaseName\\").version"`;
+if ($? == -1) {
+    warn("could not execute nix-instantiate ($!).\n");
+    exit 127;
+}
+if ($? > 0) {
+    warn("error while executing nix-instantiate ($?).\n");
+    exit $?;
+}
 chomp $d;
 if ($d == 1) {
     warn("channel would go back in time from $curRelease to $releaseName, bailing out\n");


### PR DESCRIPTION
A more durable solution would likely be to make a generic function that
wraps backticks and fails when $? is non-zero, rather than doing it
in-situ. There are other backtick uses that may be problematic