### PR TITLE
mirror: add redirection for store-paths.xz

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -331,6 +331,7 @@ redirect($channelName, $releasePrefix);
 redirect("$channelName/nixexprs.tar.xz", "$releasePrefix/nixexprs.tar.xz");
 redirect("$channelName/git-revision", "$releasePrefix/git-revision");
 redirect("$channelName/packages.json.br", "$releasePrefix/packages.json.br");
+redirect("$channelName/store-paths.xz", "$releasePrefix/store-paths.xz");
 
 # Create redirects relevant only to NixOS channels.
 # FIXME: create only redirects to files that exist.


### PR DESCRIPTION
This is intended to fix https://channels.nixos.org/nixos-19.09/store-paths.xz, which used to work at some point.

It's untested, of course.

cc @garbas @monokrome