### PR TITLE
nix install script should have Content Type set as "text/plain"

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -277,7 +277,7 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
                 my $configuration = ();
                 $configuration->{content_type} = "application/octet-stream";
 
-                if ($fn =~ /.sha256|src-url|binary-cache-url|git-revision/) {
+                if ($fn =~ /.sha256|.asc|src-url|binary-cache-url|git-revision|install/) {
                     # Text files
                     $configuration->{content_type} = "text/plain";
                 } elsif ($fn =~ /.json.br$/) {


### PR DESCRIPTION
fixes #40 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixos-channel-scripts/41)
<!-- Reviewable:end -->
