### PR TITLE
Update github link to use nixpkgs instead of nixpkgs-channels.

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -259,7 +259,7 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
 
     my $now = strftime("%F %T", localtime);
     my $title = "$channelName release $releaseName";
-    my $githubLink = "https://github.com/NixOS/nixpkgs-channels/commits/$rev";
+    my $githubLink = "https://github.com/NixOS/nixpkgs/commits/$rev";
 
     my $html = "<html><head>";
     $html .= "<title>$title</title></head>";


### PR DESCRIPTION
Hi, thank you for all your work on this package, I have a minor addendum. 
Currently, the generated github link points to the old `nixpkgs-channel` repository ([deprecated](https://github.com/NixOS/nixpkgs/issues/99257)), while still using `nixpkgs` commit hashes:
 

<img width="920" alt="Screen Shot 2021-03-14 at 7 54 17 PM" src="https://user-images.githubusercontent.com/14322653/111097701-44c1a380-84ff-11eb-861a-cc28816d6815.png">

The result is that the github link 404s. 


<img width="1343" alt="image" src="https://user-images.githubusercontent.com/14322653/111097830-7d617d00-84ff-11eb-9e26-f0cf721009aa.png">

This pull request updates the link to use `nixpkgs` proper as the repository. The correct link in this case would be [https://github.com/NixOS/nixpkgs/commits/c5147860e23ed75ce9d40298c66b416c00be1167](https://github.com/NixOS/nixpkgs/commits/c5147860e23ed75ce9d40298c66b416c00be1167).

