### PR TITLE
Generate indexes for aarch64 too

### DIFF
--- a/generate-programs-index.cc
+++ b/generate-programs-index.cc
@@ -90,7 +90,7 @@ void mainWrapped(int argc, char * * argv)
     /* Get all derivations. */
     DrvInfos packages;
 
-    for (auto system : std::set<std::string>{"x86_64-linux", "i686-linux"}) {
+    for (auto system : std::set<std::string>{"x86_64-linux", "i686-linux", "aarch64-linux"}) {
         auto args = state.allocBindings(2);
         Value * vConfig = state.allocValue();
         state.mkAttrs(*vConfig, 0);


### PR DESCRIPTION
Its useful to have the `command-not-found` helper work on aarch64 systems

Probably this should be configurable somewhere (or even the databases should be separated per architecture) but this provides a quick and simple fix