### PR TITLE
Fix typo in system name for ova image

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -250,7 +250,7 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
             downloadFile("nixos.iso_gnome.x86_64-linux");
 
             downloadFile("nixos.iso_minimal.i686-linux");
-            downloadFile("nixos.ova.x86-64-linux");
+            downloadFile("nixos.ova.x86_64-linux");
         }
 
     } else {


### PR DESCRIPTION
Failure after #57 and #58 

```
Oct 27 17:09:33 bastion systemd[1]: Starting Update Channel nixos-unstable...
Oct 27 17:09:47 bastion update-nixos-unstable-start[225055]: Release information:
Oct 27 17:09:47 bastion update-nixos-unstable-start[225055]:  - release is: nixos-22.11pre421109.5bdb380ee7f (build 196583391)
Oct 27 17:09:47 bastion update-nixos-unstable-start[225055]:  - eval is: 1784092
Oct 27 17:09:47 bastion update-nixos-unstable-start[225055]:  - prefix is: nixos/unstable/nixos-22.11pre421109.5bdb380ee7f
Oct 27 17:09:47 bastion update-nixos-unstable-start[225055]:  - Git commit is: 5bdb380ee7fa036d47b19e9d854928f4881c50a1
Oct 27 17:09:48 bastion update-nixos-unstable-start[225055]: previous release is https://releases.nixos.org/nixos/unstable/nixos-22.11pre420742.f994293d1eb
Oct 27 17:10:03 bastion update-nixos-unstable-start[225093]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:04 bastion update-nixos-unstable-start[225099]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:05 bastion update-nixos-unstable-start[225105]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:06 bastion update-nixos-unstable-start[225111]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:09 bastion update-nixos-unstable-start[225118]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:13 bastion update-nixos-unstable-start[225139]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:23 bastion update-nixos-unstable-start[225145]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:31 bastion update-nixos-unstable-start[225166]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:39 bastion update-nixos-unstable-start[225173]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:48 bastion update-nixos-unstable-start[225194]: warning: 'hash-file' is a deprecated alias for 'hash file'
Oct 27 17:10:51 bastion update-nixos-unstable-start[225055]: could not download https://hydra.nixos.org/eval/1784092/job/nixos.ova.x86-64-linux: 404 Not Found
Oct 27 17:10:51 bastion systemd[1]: update-nixos-unstable.service: Main process exited, code=exited, status=255/EXCEPTION
Oct 27 17:10:51 bastion systemd[1]: update-nixos-unstable.service: Failed with result 'exit-code'.