### PR TITLE
set cache-control on mutable objects

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -330,11 +330,17 @@ if ($channelName =~ /20.03/ || $channelName =~ /19.09/) {
     run("git push channels $rev:refs/heads/$channelName >&2");
 }
 
+# s-maxage=600: Serve from cache for 5 minutes.
+# stale-while-revaliadate=1800: Serve from cache while updating in the background for 30 minutes.
+# https://web.dev/stale-while-revalidate/
+# https://developer.fastly.com/learning/concepts/cache-freshness/
+my $redirectCacheControl = "s-maxage=600, stale-while-revalidate=1800";
+
 sub redirect {
     my ($from, $to) = @_;
     $to = "https://releases.nixos.org/" . $to;
     print STDERR "redirect $from -> $to\n";
-    $bucketChannels->add_key($from, "", { "x-amz-website-redirect-location" => $to })
+    $bucketChannels->add_key($from, "", { "x-amz-website-redirect-location" => $to, "cache-control" => $redirectCacheControl })
         or die $bucketChannels->err . ": " . $bucketChannels->errstr;
 }
 


### PR DESCRIPTION
This allows to override the default TTL on Fastly. Let it know what these objects should be refreshed more often.

Fixes NixOS/nixos-org-configurations#169