### PR TITLE
mirror-nixos-branch: fetch channel artifacts from S3 directly

### DIFF
--- a/mirror-nixos-branch.pl
+++ b/mirror-nixos-branch.pl
@@ -194,7 +194,7 @@ if ($bucketReleases && $bucketReleases->head_key("$releasePrefix")) {
         if (! -e $dstFile) {
             print STDERR "downloading $srcFile to $dstFile...\n";
             write_file("$dstFile.sha256", "$sha256_expected  $dstName");
-            runAllowFailure("NIX_REMOTE=https://cache.nixos.org/ nix --experimental-features nix-command store cat '$srcFile' > '$dstFile.tmp'") == 0
+            runAllowFailure("NIX_REMOTE=s3://nix-cache nix --experimental-features nix-command store cat '$srcFile' > '$dstFile.tmp'") == 0
                 or die "unable to fetch $srcFile\n";
             rename("$dstFile.tmp", $dstFile) or die;
         }


### PR DESCRIPTION
Tested that the script runs with appropriate credentials on `bastion` right now, but I haven't end-to-end tested this change. My testing was running the `nix store cat` command as `hydra-mirror` on bastion.

----

The channel scripts hit into NixOS/nixos-org-configurations#212 sometimes when fetching ISOs from cache.nixos.org to copy to the channels bucket. This makes runs take hours when they should take minutes.

There is no benefit gained from going through cache.nixos.org for this use case. As noticed by @K900, the .iso nar.xz files on the cache are unlikely to be touched by anyone other than the channel scripts, so we don't even end up pre-warming the cache or anything along those lines - if anything, we just waste cache bytes that could be used by other paths.

Fixes #67.